### PR TITLE
fix uproot version to <4.2.4 

### DIFF
--- a/DL2/Dockerfile
+++ b/DL2/Dockerfile
@@ -20,10 +20,9 @@ COPY Converters/DL2/environment.yml environment.yml
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /conda && \
     rm ~/miniconda.sh && \
-    /conda/bin/conda clean -tipsy && \
-    /conda/bin/conda install -c conda-forge mamba
-RUN mamba env update -n base --file environment.yml && \
-    mamba clean --all && conda remove --yes mamba && conda clean --all
+    /conda/bin/conda clean -tipsy
+RUN conda env update -n base --file environment.yml && \
+    conda clean --all
 
 WORKDIR /workdir/
 

--- a/DL2/Dockerfile
+++ b/DL2/Dockerfile
@@ -19,8 +19,7 @@ COPY Converters/DL2/environment.yml environment.yml
 
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /conda && \
-    rm ~/miniconda.sh && \
-    /conda/bin/conda clean -tipsy
+    rm ~/miniconda.sh
 RUN conda env update -n base --file environment.yml && \
     conda clean --all
 

--- a/DL2/environment.yml
+++ b/DL2/environment.yml
@@ -15,4 +15,4 @@ dependencies:
   - astropy
   - click
   - python
-  - uproot
+  - uproot=4.2.4


### PR DESCRIPTION
See issue #25 for the problem with uproot >=5. This is an intermediate fix to keep the code working.

Removed also mamba from the Docker generation and replaced it by conda (not sure why mamba stops working in this context).