### PR TITLE
Add uncertainty column to effective area and fix PSF_TABLE column names

### DIFF
--- a/DL3-IRFs/inc/VDL3IRFs.h
+++ b/DL3-IRFs/inc/VDL3IRFs.h
@@ -32,7 +32,8 @@ class VDL3IRFs
                         string name,
                         char* col_name,
                         char* col_unit,
-                        bool MEV_BACKGROUND_UNIT = false );
+                        bool MEV_BACKGROUND_UNIT = false,
+                        bool include_uncertainty = false );
 
 
     public:

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -151,7 +151,7 @@ bool VDL3IRFs::write_fits_table_header( string irftype, char *instrument )
                        (char*)"RESPONSE",
                        (char*)"HDUCLAS1" );
 
-   if( irftype == "POINT SPREAD FUNCTION" || irftype == "PSF_TABLE" )
+   if( irftype == "PSF_3GAUSS" || irftype == "PSF_TABLE" )
    {
        write_fits_keyword( (char*)"HDUCLAS2",
                            (char*)"PSF",
@@ -555,7 +555,7 @@ bool VDL3IRFs::write_psf_gauss( TH2F *h, char *instrument )
    }
 
    bool writing_success = write_table( table );
-   write_fits_table_header( "POINT SPREAD FUNCTION", instrument );
+   write_fits_table_header( "PSF_3GAUSS", instrument );
 
    return writing_success;
 }

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -406,7 +406,7 @@ bool VDL3IRFs::write_psf_table( TH3F *h, char *instrument )
                         tType,
                         tForm,
                         tUnit,
-                        "POINT SPREAD FUNCTION",
+                        "PSF_TABLE",
                         &status ) )
    {
        return printerror( status );
@@ -503,7 +503,7 @@ bool VDL3IRFs::write_psf_gauss( TH2F *h, char *instrument )
                         tType,
                         tForm,
                         tUnit,
-                        "POINT SPREAD FUNCTION",
+                        "PSF_3GAUSS",
                         &status ) )
    {
        return printerror( status );

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -899,7 +899,7 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
                              * norm_mev_background[i] );
               if( include_uncertainty )
               {
-                  // Get bin error (averaging asymmetric errors if available)
+                  // Get the symmetric bin error and scale it with the background normalisation
                   float error = h->GetBinError( i+1, j+1 );
                   errors.push_back( error * norm_mev_background[i] );
               }

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -337,8 +337,10 @@ bool VDL3IRFs::write_edisp( TH3F *h, char *instrument )
    table.push_back( data );
 
    bool writing_success = write_table( table );
-   write_fits_table_header( "EDISP_2D", instrument );
-
+   if( writing_success )
+   {
+       write_fits_table_header( "EDISP_2D", instrument );
+   }
    return writing_success;
 }
 
@@ -739,7 +741,10 @@ bool VDL3IRFs::write_background_3D_from_2d( TH2F* h, char *instrument )
 
    bool writing_success = write_table( table );
 
-   write_fits_table_header( "BKG_3D", instrument );
+   if( writing_success )
+   {
+       write_fits_table_header( "BKG_3D", instrument );
+   }
    return writing_success;
 }
 
@@ -754,7 +759,10 @@ bool VDL3IRFs::write_background( TH2F *h, char *instrument )
                       (char*)"BKG",
                       (char*)"s^-1 MeV^-1 sr^-1",
                       true );
-   write_fits_table_header( "BKG_2D", instrument );
+   if( writing_success )
+   {
+       write_fits_table_header( "BKG_2D", instrument );
+   }
    return writing_success;
 }
 
@@ -770,7 +778,10 @@ bool VDL3IRFs::write_effarea( TH2F *h, char *instrument )
                       (char*)"m**2",
                       false,
                       true );
-   write_fits_table_header( "AEFF_2D", instrument );
+   if( writing_success )
+   {
+       write_fits_table_header( "AEFF_2D", instrument );
+   }
    return writing_success;
 }
 
@@ -785,7 +796,10 @@ bool VDL3IRFs::write_diffsens( TH2F *h, char *instrument )
                       (char*)"DIFFSENS",
                       (char*)"erg cm^-2 s^-1",
                       false );
-   write_fits_table_header( "DIFFSENS_2D", instrument );
+   if( writing_success )
+   {
+       write_fits_table_header( "DIFFSENS_2D", instrument );
+   }
    return writing_success;
 }
 

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -363,10 +363,10 @@ bool VDL3IRFs::write_psf_table( TH3F *h, char *instrument )
    nRows = 0;
    char* tType[nCol] = { (char*)"ENERG_LO",
                       (char*)"ENERG_HI",
+                      (char*)"RAD_LO",
+                      (char*)"RAD_HI",
                       (char*)"THETA_LO",
                       (char*)"THETA_HI",
-                      (char*)"MIGRA_LO",
-                      (char*)"MIGRA_HI",
                       (char*)"RPSF" };
    char* tUnit[nCol] = { (char*)"TeV",
                       (char*)"TeV",
@@ -378,10 +378,10 @@ bool VDL3IRFs::write_psf_table( TH3F *h, char *instrument )
    // e_true axis is x-axis
    char x_form[10];
    sprintf( x_form, "%dE", h->GetNbinsX() );
-   // Offset angle from source position
+   // Offset angle from source position (y-axis, RAD)
    char y_form[10];
    sprintf( y_form, "%dE", h->GetNbinsY() );
-   // offset angle axis is z-axis
+   // Field of view offset angle (z-axis, THETA)
    char z_form[10];
    sprintf( z_form, "%dE", h->GetNbinsZ() );
    // mig
@@ -764,7 +764,8 @@ bool VDL3IRFs::write_effarea( TH2F *h, char *instrument )
                       "EFFECTIVE AREA",
                       (char*)"EFFAREA",
                       (char*)"m**2",
-                      false );
+                      false,
+                      true );
    write_fits_table_header( "AEFF_2D", instrument );
    return writing_success;
 }
@@ -791,35 +792,50 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
                                string name,
                                char* col_name,
                                char* col_unit,
-                               bool MEV_BACKGROUND_UNIT )
+                               bool MEV_BACKGROUND_UNIT,
+                               bool include_uncertainty )
 {
    if( !h ) return false;
 
    int status = 0;
-   const int nCol = 5;
+   const int nCol = include_uncertainty ? 6 : 5;
+   const int maxCol = 6;  // Maximum possible columns (with uncertainty)
    long nRows = h->GetNbinsX() * h->GetNbinsY();
    nRows = 0;
-   char* tType[nCol] = { (char*)"ENERG_LO",
-                      (char*)"ENERG_HI",
-                      (char*)"THETA_LO",
-                      (char*)"THETA_HI",
-                      (char*)col_name };
-   char* tUnit[nCol] = { (char*)"TeV",
-                      (char*)"TeV",
-                      (char*)"deg",
-                      (char*)"deg",
-                      (char*)col_unit };
+   
+   // Column names - create error column name in static buffer
+   char err_col_name[50];
+   if( include_uncertainty )
+   {
+       snprintf( err_col_name, sizeof(err_col_name), "%s_ERR", col_name );
+   }
+   
+   // Arrays sized for maximum columns; fits_create_tbl uses only first nCol entries
+   char* tType[maxCol] = { (char*)"ENERG_LO",
+                           (char*)"ENERG_HI",
+                           (char*)"THETA_LO",
+                           (char*)"THETA_HI",
+                           (char*)col_name,
+                           include_uncertainty ? err_col_name : (char*)"" };
+   
+   char* tUnit[maxCol] = { (char*)"TeV",
+                           (char*)"TeV",
+                           (char*)"deg",
+                           (char*)"deg",
+                           (char*)col_unit,
+                           (char*)col_unit };
    char x_form[10];
    sprintf( x_form, "%dE", h->GetNbinsX() );
    char y_form[10];
    sprintf( y_form, "%dE", h->GetNbinsY() );
    char z_form[10];
    sprintf( z_form, "%dE", h->GetNbinsX()*h->GetNbinsY() );
-   char* tForm[nCol] = { &x_form[0],
-                      &x_form[0],
-                      &y_form[0],
-                      &y_form[0],
-                      &z_form[0] };
+   char* tForm[maxCol] = { &x_form[0],
+                           &x_form[0],
+                           &y_form[0],
+                           &y_form[0],
+                           &z_form[0],
+                           &z_form[0] };
 
    ///////////////
    // create empty table
@@ -845,6 +861,18 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
    {
       return printerror( status );
    }
+   // set dimensions for uncertainty column if present
+   if( include_uncertainty )
+   {
+       if( fits_write_tdim( fptr,
+                            6,
+                            2,
+                            naxes,
+                            &status ) )
+       {
+          return printerror( status );
+       }
+   }
    ///////////////
    // write data
    vector< vector< float > > table = get_baseline_axes( h );
@@ -858,6 +886,7 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
 
    // data
    vector< float > data;
+   vector< float > errors;
    for( int j = 0; j < h->GetNbinsY(); j++ )
    {
       for( int i = 0; i < h->GetNbinsX(); i++ )
@@ -868,15 +897,31 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
           {
               data.push_back( h->GetBinContent( i+1, j+1 )
                              * norm_mev_background[i] );
+              if( include_uncertainty )
+              {
+                  // Get bin error (averaging asymmetric errors if available)
+                  float error = h->GetBinError( i+1, j+1 );
+                  errors.push_back( error * norm_mev_background[i] );
+              }
           }
           else
           {
               data.push_back( h->GetBinContent( i+1, j+1 ) );
+              if( include_uncertainty )
+              {
+                  errors.push_back( h->GetBinError( i+1, j+1 ) );
+              }
           }
 
       }
    }
    table.push_back( data );
+   
+   // Add uncertainty column if requested
+   if( include_uncertainty )
+   {
+       table.push_back( errors );
+   }
 
    return write_table( table );
 }

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -151,7 +151,7 @@ bool VDL3IRFs::write_fits_table_header( string irftype, char *instrument )
                        (char*)"RESPONSE",
                        (char*)"HDUCLAS1" );
 
-   if( irftype == "PSF_3GAUSS" )
+   if( irftype == "PSF_3GAUSS" || irftype == "PSF_TABLE" )
    {
        write_fits_keyword( (char*)"HDUCLAS2",
                            (char*)"PSF",

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -803,11 +803,11 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
    long nRows = h->GetNbinsX() * h->GetNbinsY();
    nRows = 0;
    
-   // Column names - create error column name in static buffer
-   char err_col_name[50];
+   // Column names - create error column name using std::string
+   string err_col_name;
    if( include_uncertainty )
    {
-       snprintf( err_col_name, sizeof(err_col_name), "%s_ERR", col_name );
+       err_col_name = string(col_name) + "_ERR";
    }
    
    // Arrays sized for maximum columns; fits_create_tbl uses only first nCol entries
@@ -816,7 +816,7 @@ bool VDL3IRFs::write_histo2D( TH2F *h,
                            (char*)"THETA_LO",
                            (char*)"THETA_HI",
                            (char*)col_name,
-                           include_uncertainty ? err_col_name : (char*)"" };
+                           include_uncertainty ? (char*)err_col_name.c_str() : (char*)"" };
    
    char* tUnit[maxCol] = { (char*)"TeV",
                            (char*)"TeV",

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -440,10 +440,12 @@ bool VDL3IRFs::write_psf_table( TH3F *h, char *instrument )
    }
    table.push_back( data );
 
-   write_table( table );
-   write_fits_table_header( "PSF_TABLE", instrument );
-
-   return true;
+   bool writing_success = write_table( table );
+   if( writing_success )
+   {
+       write_fits_table_header( "PSF_TABLE", instrument );
+   }
+   return writing_success;
 }
 
 /*
@@ -555,8 +557,10 @@ bool VDL3IRFs::write_psf_gauss( TH2F *h, char *instrument )
    }
 
    bool writing_success = write_table( table );
-   write_fits_table_header( "PSF_3GAUSS", instrument );
-
+   if( writing_success )
+   {
+       write_fits_table_header( "PSF_3GAUSS", instrument );
+   }
    return writing_success;
 }
 

--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -151,7 +151,7 @@ bool VDL3IRFs::write_fits_table_header( string irftype, char *instrument )
                        (char*)"RESPONSE",
                        (char*)"HDUCLAS1" );
 
-   if( irftype == "PSF_3GAUSS" || irftype == "PSF_TABLE" )
+   if( irftype == "POINT SPREAD FUNCTION" || irftype == "PSF_TABLE" )
    {
        write_fits_keyword( (char*)"HDUCLAS2",
                            (char*)"PSF",
@@ -503,7 +503,7 @@ bool VDL3IRFs::write_psf_gauss( TH2F *h, char *instrument )
                         tType,
                         tForm,
                         tUnit,
-                        "PSF_3GAUSS",
+                        "POINT SPREAD FUNCTION",
                         &status ) )
    {
        return printerror( status );
@@ -555,7 +555,7 @@ bool VDL3IRFs::write_psf_gauss( TH2F *h, char *instrument )
    }
 
    bool writing_success = write_table( table );
-   write_fits_table_header( "PSF_3GAUSS", instrument );
+   write_fits_table_header( "POINT SPREAD FUNCTION", instrument );
 
    return writing_success;
 }

--- a/DL3-IRFs/src/convertSensitivityFilesToFITS.cpp
+++ b/DL3-IRFs/src/convertSensitivityFilesToFITS.cpp
@@ -89,11 +89,15 @@ int main( int argc, char* argv[] )
 
     cout << "Writing gamma-ray point-spread function (3D table)" << endl;
     TH3F* psf_table_hist = (TH3F*)fData->Get( "AngularPSF2DEtrue_offaxis" );
-    if( psf_table_hist ) {
-        if( !a.write_psf_table( psf_table_hist, (char*)getArrayName(fData) ) ) {
+    if( psf_table_hist )
+    {
+        if( !a.write_psf_table( psf_table_hist, (char*)getArrayName(fData) ) )
+        {
             cerr << "Error: Failed to write PSF_TABLE" << endl;
         }
-    } else {
+    }
+    else
+    {
         cout << "Warning: AngularPSF2DEtrue_offaxis histogram not found, skipping PSF_TABLE" << endl;
     }
 

--- a/DL3-IRFs/src/convertSensitivityFilesToFITS.cpp
+++ b/DL3-IRFs/src/convertSensitivityFilesToFITS.cpp
@@ -87,12 +87,10 @@ int main( int argc, char* argv[] )
          (TH2F*)fData->Get( "AngResEtrue_offaxis" ),
          (char*)getArrayName(fData) );
 
-    /*
     cout << "Writing gamma-ray point-spread function (3D table)" << endl;
     a.write_psf_table(
          (TH3F*)fData->Get( "AngularPSF2DEtrue_offaxis" ),
          (char*)getArrayName(fData) );
-    */
 
     // edisp
     // note: note using migration matrix MigMatrixNoTheta2cut_offaxis

--- a/DL3-IRFs/src/convertSensitivityFilesToFITS.cpp
+++ b/DL3-IRFs/src/convertSensitivityFilesToFITS.cpp
@@ -88,9 +88,14 @@ int main( int argc, char* argv[] )
          (char*)getArrayName(fData) );
 
     cout << "Writing gamma-ray point-spread function (3D table)" << endl;
-    a.write_psf_table(
-         (TH3F*)fData->Get( "AngularPSF2DEtrue_offaxis" ),
-         (char*)getArrayName(fData) );
+    TH3F* psf_table_hist = (TH3F*)fData->Get( "AngularPSF2DEtrue_offaxis" );
+    if( psf_table_hist ) {
+        if( !a.write_psf_table( psf_table_hist, (char*)getArrayName(fData) ) ) {
+            cerr << "Error: Failed to write PSF_TABLE" << endl;
+        }
+    } else {
+        cout << "Warning: AngularPSF2DEtrue_offaxis histogram not found, skipping PSF_TABLE" << endl;
+    }
 
     // edisp
     // note: note using migration matrix MigMatrixNoTheta2cut_offaxis


### PR DESCRIPTION
- Add optional include_uncertainty parameter to write_histo2D function
- Enable uncertainty column (EFFAREA_ERR) for effective area table
- Fix PSF_TABLE column names: MIGRA->RAD and swap THETA/RAD positions for GADF compliance
- Uncomment write_psf_table call to enable 3D PSF table generation