### PR TITLE
Fix PSF scale 

### DIFF
--- a/DL3-IRFs/src/VDL3IRFs.cpp
+++ b/DL3-IRFs/src/VDL3IRFs.cpp
@@ -542,7 +542,9 @@ bool VDL3IRFs::write_psf_gauss( TH2F *h, char *instrument )
           data.push_back( h->GetBinContent( i+1, j+1 ) * 0.6624305 );
           if( data.back() > 0. )
           {
-             scale.push_back( 1./ (2.*TMath::Pi()*data.back() ) );
+             // SCALE = 1/(2*pi*sigma_rad^2)
+             float sigma_rad = data.back() * TMath::Pi() / 180.;
+             scale.push_back( 1./ (2.*TMath::Pi()*sigma_rad*sigma_rad) );
           }
           else
           {


### PR DESCRIPTION
Issue number 3 reported in #33 is fixed with this PR.

It should be noted that the error did not have an effect on the results obtained so far with the IRFs produced. This was tested both at the IRF level and with DL3 simulated events (point source and diffuse source). It most likely had no effect because the PSF is renormalised before use (confirmation pending).

